### PR TITLE
feat: Add Visits tab to Deal and Lead pages with backend APIs

### DIFF
--- a/crm/fcrm/doctype/crm_deal/api.py
+++ b/crm/fcrm/doctype/crm_deal/api.py
@@ -77,3 +77,16 @@ def get_linked_quotations(args):
 	# 	quotation["customer"] = frappe.bold(quotation["customer"])
 
 	return quotations
+
+# crm/fcrm/doctype/crm_deal/api.py
+
+@frappe.whitelist()
+def get_deal_visits(dealId):
+    return frappe.get_all(
+        "CRM Site Visit",
+        filters={
+            "reference_type": "CRM Deal",
+            "reference_name": dealId
+        },
+        fields=["*"]
+    )

--- a/crm/fcrm/doctype/crm_lead/api.py
+++ b/crm/fcrm/doctype/crm_lead/api.py
@@ -15,3 +15,14 @@ def get_lead(name):
 	lead["_form_script"] = get_form_script("CRM Lead")
 	lead["_assign"] = get_assigned_users("CRM Lead", lead.name)
 	return lead
+
+@frappe.whitelist()
+def get_lead_visits(leadId):
+    return frappe.get_all(
+        "CRM Site Visit",
+        filters={
+            "reference_type": "CRM Lead",
+            "reference_name": leadId
+        },
+        fields=["*"]
+    )


### PR DESCRIPTION
- Added Visits tab to Deal and Lead pages in the frontend
- Created backend APIs to fetch visits linked to CRM Deal and CRM Lead using reference_type and reference_name filters
- Integrated API calls in frontend using createResource for both Deal and Lead pages
- Rendered visits data (date, status, type, priority, etc.) in the Visits tab for both entities